### PR TITLE
ignore-scripts=false

### DIFF
--- a/files/.npmrc
+++ b/files/.npmrc
@@ -1,2 +1,2 @@
 engine-strict=true
-ignore-scripts=true
+# ignore-scripts=true This causes `npm test` to not run (node 14, npm 6, on CI)


### PR DESCRIPTION
This causes `npm test` to not run (node 14, npm 6, on CI)